### PR TITLE
Add Workflow to enforce comments on all PRs

### DIFF
--- a/.github/workflows/pr_comment_check.yml
+++ b/.github/workflows/pr_comment_check.yml
@@ -1,0 +1,28 @@
+---
+name: Enforce Comment Requirement on PR
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+
+jobs:
+  check-comments:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check for PR Comments
+        uses: actions/github-script@v6
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        with:
+          script: |
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            });
+
+            if (comments.length === 0) {
+              core.setFailed("PR cannot be merged until it has at least one comment.");
+            } else {
+              console.log("PR has comments and is ready for review.");
+            }


### PR DESCRIPTION
Signed-off-by: Shehzad <shehzadashiq@hotmail.com>

# Description of PR

Adds an action that requires a comment on a PR to apply. This action needs to be used in combination with a protection ruleset to work.

## Contributors

@shehzadashiq

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
